### PR TITLE
ci: add release script

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,7 +2,7 @@
 
 DDCS，全称Docker Desktop Chinese Script，即Docker汉化脚本。
 
-MAC版本请切换到MAC分支。
+master 分支目前支持 Windows / Mac。
 
 <big>**你可以在这个仓库找到各个版本的汉化包：【 https://github.com/asxez/DockerDesktop-CN 】**</big>
 

--- a/config.json
+++ b/config.json
@@ -73,6 +73,10 @@
       "dest": "\"我的扩展\","
     },
     {
+      "src": "\"Manage Extensions\":\"Extensions Marketplace\"",
+      "dest": "\"管理扩展\":\"扩展市场\""
+    },
+    {
       "src": "title:\"Add Extensions\"",
       "dest": "title:\"添加扩展\""
     },
@@ -183,6 +187,10 @@
     {
       "src": "title:\"Images are used to run containers\",description:\"You can either build an image from a Dockerfile, or download an existing image to run\",buttonTitle:\"Search images to run\"",
       "dest": "title:\"镜像用于运行容器\",description:\"您可以从 Dockerfile 构建镜像，也可以下载现有镜像以运行\",buttonTitle:\"搜索要运行的镜像\""
+    },
+    {
+      "src": "label:b,value:\"local\"",
+      "dest": "label:\"本地\",value:\"local\""
     },
     {
       "src": "label:\"Hub\",value:\"hub\"",
@@ -865,12 +873,20 @@
       "dest": "Docker Desktop 已被阻"
     },
     {
+      "src": "Docker Desktop ${t}",
+      "dest": "Docker Desktop 运行中"
+    },
+    {
       "src": "\"Docker Desktop paused\"",
       "dest": "\"Docker Desktop 暂停中\""
     },
     {
       "src": "\"Docker Desktop is running in Resource Saver mode\"",
       "dest": "\"Docker Desktop 正在节能模式下运行\""
+    },
+    {
+      "src": "Kubernetes is running",
+      "dest": "Kubernetes 正在运行"
     },
     {
       "src": "label:\"Documentation\"",

--- a/ddcs.py
+++ b/ddcs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2024 ASXE  All Rights Reserved 
+# Copyright (C) 2024 ASXE  All Rights Reserved
 #
 # @Time    : 2024/8/9 下午4:17
 # @Author  : ASXE
@@ -24,46 +24,58 @@ def cost_time(func):
 
 
 @cost_time
-def run(root_path, config_path):
-    log.info('脚本已启动...')
+def run(root_path: str, config_path: str, process_asar: bool):
+    log.info("脚本已启动...")
     time.sleep(1)
 
-    DDProcessor(True)
+    if process_asar:
+        DDProcessor(True)
 
     fp = FileProcessor(root_path, config_path)
     file_paths = fp.recursive_listdir()
-    log.info('汉化开始')
+    log.info("汉化开始")
     for transformation in fp.get_transformations():
-        search = transformation['src']
-        replacement = transformation['dest']
+        search = transformation["src"]
+        replacement = transformation["dest"]
         replaced = fp.process_files(file_paths, search, replacement)
         if not replaced:
             log.warn(search)
         else:
             log.info(f"{search} -> {replacement}")
 
-    DDProcessor(False)
+    if process_asar:
+        DDProcessor(False)
 
 
 @cost_time
-def run_v2(root_path: str):
+def run_v2(root_path: str, process_asar: bool):
     log.info("脚本已启动...")
     time.sleep(1)
 
-    DDProcessor(True)
+    if process_asar:
+        DDProcessor(True)
     log.info("汉化开始")
     replace(Path(root_path))
-    DDProcessor(False)
+    if process_asar:
+        DDProcessor(False)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--v2", action="store_true")
+    parser.add_argument("--root_path", type=str, default=None)
     args = parser.parse_args()
 
-    root_path = "./app/build/"
+    if not args.root_path:
+        # 没有传递 root_path, 认为需要从安装目录 cp
+        root_path = "./app/build/"
+        process_asar = True
+    else:
+        root_path = args.root_path
+        process_asar = False
+    print(root_path, process_asar)
     config_path = "./config.json"
     if args.v2:
-        run_v2(root_path)
+        run_v2(root_path, process_asar)
     else:
-        run(root_path, config_path)
+        run(root_path, config_path, process_asar)

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,90 @@
+set -ex
+
+targe_repo="asxez/DockerDesktop-CN"
+
+rm -rf tmp && mkdir -p dist tmp
+
+# repo latest release
+release=$(gh release view --repo "${targe_repo}" --json tagName --jq .tagName || echo "")
+# docker desktop latest version
+wget -q -O tmp/release-notes.md https://github.com/docker/docs/raw/refs/heads/main/content/manuals/desktop/release-notes.md
+# e.g. 4.39.0
+version=$(grep -oPm 1 '{{<\s(?!release-date).*?all=true.*?version="\K[^"]+' tmp/release-notes.md)
+if [ "${release}" == "${version}" ]; then
+    echo "We already have the latest version"
+    exit 0
+fi
+
+# install 7z
+if [ ! -e "./7z/7zz" ]; then
+  mkdir -p 7z
+  wget -q -O 7z/7z.tar.xz https://www.7-zip.org/a/7z2409-linux-x64.tar.xz
+  tar -xf 7z/7z.tar.xz -C 7z
+fi
+
+# install asar
+if ! command -v "7zz" >/dev/null; then
+  npm install -g asar
+fi
+
+# install requirements
+pip install black
+
+# download dd
+build_path=$(grep -oPm 1 '{{<\s(?!release-date).*?all=true.*?build_path="\K[^"]+' tmp/release-notes.md)
+if [ ! -e "dist/DockerDesktop-${version}-Windows-x86.exe" ]; then
+    wget -q -O "dist/DockerDesktop-${version}-Windows-x86.exe" "https://desktop.docker.com/win/main/amd64${build_path}Docker%20Desktop%20Installer.exe"
+fi
+if [ ! -e "dist/DockerDesktop-${version}-Windows-arm.exe" ]; then
+    wget -q -O "dist/DockerDesktop-${version}-Windows-arm.exe" "https://desktop.docker.com/win/main/arm64${build_path}Docker%20Desktop%20Installer.exe"
+fi
+if [ ! -e "dist/DockerDesktop-${version}-Mac-apple.dmg" ]; then
+    wget -q -O "dist/DockerDesktop-${version}-Mac-apple.dmg" "https://desktop.docker.com/mac/main/arm64${build_path}Docker.dmg"
+fi
+if [ ! -e "dist/DockerDesktop-${version}-Mac-intel.dmg" ]; then
+    wget -q -O "dist/DockerDesktop-${version}-Mac-intel.dmg" "https://desktop.docker.com/mac/main/amd64${build_path}Docker.dmg"
+fi
+
+# unzip, extract, replace, pack
+function ddcs() {
+    pkg_name=$1
+    # win-x86, win-arm, mac-apple, mac-intel
+    arch=$(echo "$pkg_name" | sed -nr 's/DockerDesktop-.+-(.+-.+)\..+/\1/p')
+
+    if [ -e "app-${arch}.asar" ]; then
+        return
+    fi
+
+    ./7z/7zz x "dist/${pkg_name}" -y -o"tmp/${arch}" -bso0 -bd || true
+    if [[ $arch == Windows* ]]; then
+        src="frontend/resources"
+    elif [[ $arch == Mac* ]]; then
+        src="Docker/Docker.app/Contents/MacOS/Docker Desktop.app/Contents/Resources"
+    else
+       echo "unknown arch"
+       exit 1
+    fi
+    rm -rf "tmp/app-${arch}.asar" "tmp/app-${arch}.asar.unpacked"
+    mv "tmp/${arch}/${src}/app.asar" "tmp/app-${arch}.asar"
+    mv "tmp/${arch}/${src}/app.asar.unpacked" "tmp/app-${arch}.asar.unpacked"
+
+    asar extract "tmp/app-${arch}.asar" "tmp/app-${arch}"
+    python ddcs.py --root_path "tmp/app-${arch}" > /dev/null
+    asar pack "tmp/app-${arch}" "dist/app-${arch}.asar"
+
+    asar extract "tmp/app-${arch}.asar" "tmp/app-${arch}"
+    python ddcs.py --root_path "tmp/app-${arch}" --v2 > /dev/null
+    asar pack "tmp/app-${arch}" "dist/app-${arch}-v2beta.asar"
+}
+
+ddcs "DockerDesktop-${version}-Windows-x86.exe"
+ddcs "DockerDesktop-${version}-Windows-arm.exe"
+ddcs "DockerDesktop-${version}-Mac-apple.dmg"
+ddcs "DockerDesktop-${version}-Mac-intel.dmg"
+
+
+notes="ockerDesktop ${version} 版本安装程序及汉化包.
+
+注意: v2beta 包含更多的翻译, 但可能无法正常工作"
+
+gh release create "${version}" --repo "${targe_repo}" --notes "$notes" ./dist/*


### PR DESCRIPTION
为 DockerDesktop-CN Action 提供打包脚本,

以及相关修改, 包括
- 添加 root_path 参数, 传递 root_path 则认为不需要从安装目录复制解压 asar
- DDProcessor 根据系统动态导入相关依赖 (windows: winreg) , 寻找安装目录并复制解压 asar

脚本流程:
1. 手动爬取 Docker Desktop release-notes 并与 https://github.com/asxez/DockerDesktop-CN release 比较是否有新版本
2. 下载各个 arch 安装包并 7z 解压
3. 调用 ddcs 完成汉化
4. 发布 release
